### PR TITLE
tidying up npm scripts section and making npm run clean a little heavier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "postinstall": "node_modules/.bin/rn-nodeify --install assert,buffer,crypto,http,https,events,net,path,process,stream,vm --hack",
-    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "postinstall": "rn-nodeify --install assert,buffer,crypto,http,https,events,net,path,process,stream,vm --hack",
+    "start": "react-native start",
     "test": "jest",
-    "clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean --force",
+    "clean": "rm -rf node_modules && rm -rf ./ios/build/ModuleCache && rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean --force",
     "clean:android": "cd android/ && ./gradlew clean && cd .. && react-native run-android",
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build && rm -rf node_modules/ && npm cache clean --force && npm i",
     "test:watch": "jest --watch",


### PR DESCRIPTION
making npm run clean a little heavier. tidying up any commands specifying ./node_modules. no need to type the full path for any executable that appears in ./node_modules/.bin. any command specified in the "bin" section of a child dependency will get linked into there and npm will find them automatically